### PR TITLE
Update directives

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -102,10 +102,10 @@ func (f *federation) InjectSourceEarly() *ast.Source {
 `
 	} else if f.Version == 2 {
 		input += `
-	directive @key(fields: _FieldSet!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+	directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
 	directive @link(import: [String!], url: String!) repeatable on SCHEMA
 	directive @shareable on OBJECT | FIELD_DEFINITION
-	directive @tag repeatable on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+	directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 	directive @override(from: String!) on FIELD_DEFINITION
 	directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 `


### PR DESCRIPTION
# Goal
- Update `@key` and `@tag` directives for Apollo Studio

# Notes
## Issue
We have two builds errors when building supegraph because of outdated directives
```
DIRECTIVE_DEFINITION_INVALID

[new-quote] Invalid definition for directive "@key": argument "resolvable" should have default value true but found default value null

DIRECTIVE_DEFINITION_INVALID

[new-quote] Invalid definition for directive "@tag": missing required argument "name"
```

These updated directives come from the [Apollo Federation V2 Documentation](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#key)

I hope we don't have to update any implementation for this change.
## Testing Update
We can probably just import this repo if we merge this to `master`. I'm not 100% sure though.